### PR TITLE
Support components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.rmsy.Channels</groupId>
     <artifactId>Channels</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
 
     <name>Channels</name>
     <description>Channels is a simple chat channel plugin and API.</description>

--- a/src/main/java/com/github/rmsy/channels/Channel.java
+++ b/src/main/java/com/github/rmsy/channels/Channel.java
@@ -1,6 +1,8 @@
 package com.github.rmsy.channels;
 
 import com.google.common.collect.ImmutableSet;
+import net.md_5.bungee.api.chat.BaseComponent;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permission;
 
@@ -8,41 +10,25 @@ import javax.annotation.Nullable;
 
 /** Interface to represent a chat channel. */
 public interface Channel {
-    /**
-     * Gets the channel's format.
-     *
-     * @return The channel's format.
-     * @see #setFormat(String)
-     */
-    public String getFormat();
+
 
     /**
-     * Sets the channel's format.
+     * Creates the channel's format.
      *
-     * @param format The format.
+     * @param message the message.
+     * @param sender the sender, null if console.
+     * @param receiver the receiver.
+     * @param broadcast whether this is a broadcast.
+     * @return the formatted component.
      */
-    public void setFormat(String format);
-    /**
-     * Gets the channel's broadcast format.
-     *
-     * @return The channel's format.
-     * @see #setFormat(String)
-     */
-    public String getBroadcastFormat();
-
-    /**
-     * Sets the channel's broadcast format.
-     *
-     * @param format The format.
-     */
-    public void setBroadcastFormat(String format);
+    BaseComponent getFormat(final BaseComponent message, @Nullable final Player sender, final CommandSender receiver, boolean broadcast);
 
     /**
      * Gets the users who are sending to this channel by default.
      *
      * @return The users who are sending to this channel by default.
      */
-    public ImmutableSet<String> getMembers();
+    ImmutableSet<String> getMembers();
 
     /**
      * Sends a new message to the channel.
@@ -51,7 +37,16 @@ public interface Channel {
      * @param sender  The message sender, or null for console.
      * @return Whether or not the message was sent.
      */
-    public boolean sendMessage(final String message, @Nullable final Player sender);
+    boolean sendMessage(final BaseComponent message, @Nullable final Player sender);
+
+    /**
+     * Sends a new message to the channel.
+     *
+     * @param message The message to be sent.
+     * @param sender  The message sender, or null for console.
+     * @return Whether or not the message was sent.
+     */
+    boolean sendMessage(String message, @Nullable final Player sender);
 
     /**
      * Gets the permission node that is required for listening on this channel. Users without this permission node will
@@ -59,12 +54,20 @@ public interface Channel {
      *
      * @return The permission node that is required for listening on this channel.
      */
-    public Permission getListeningPermission();
+    Permission getListeningPermission();
 
     /**
      * Broadcasts a message to the channel.
      *
      * @param message The message to be broadcast.
      */
-    public void broadcast(final String message);
+    void broadcast(final BaseComponent message);
+
+    /**
+     * Broadcasts a message to the channel.
+     *
+     * @param message The message to be broadcast.
+     */
+    void broadcast(String message);
+
 }

--- a/src/main/java/com/github/rmsy/channels/ChannelsPlugin.java
+++ b/src/main/java/com/github/rmsy/channels/ChannelsPlugin.java
@@ -9,14 +9,19 @@ import com.google.common.base.Preconditions;
 import com.sk89q.bukkit.util.BukkitCommandsManager;
 import com.sk89q.bukkit.util.CommandsManagerRegistration;
 import com.sk89q.minecraft.util.commands.*;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.Configuration;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import javax.annotation.Nullable;
 
 public class ChannelsPlugin extends JavaPlugin {
     public static final String GLOBAL_CHANNEL_PARENT_NODE = "channels.global";
@@ -93,13 +98,12 @@ public class ChannelsPlugin extends JavaPlugin {
         config.options().copyDefaults(true);
         this.saveConfig();
 
-        this.globalChannel = new SimpleChannel(
-                config.getString(
-                        "global-chat.format",
-                        ChatColor.WHITE + "<{1}" + ChatColor.RESET + ChatColor.WHITE + ">: {3}"
-                ),
-                new Permission(ChannelsPlugin.GLOBAL_CHANNEL_PARENT_NODE, PermissionDefault.TRUE)
-        );
+        this.globalChannel = new SimpleChannel(new Permission(ChannelsPlugin.GLOBAL_CHANNEL_PARENT_NODE, PermissionDefault.TRUE)) {
+            @Override
+            public BaseComponent getFormat(BaseComponent message, @Nullable Player sender, CommandSender receiver, boolean broadcast) {
+                return broadcast ? new TextComponent(new TextComponent("[Broadcast] "), message) : new TextComponent(new TextComponent("<"), new TextComponent(sender != null ? sender.getDisplayName(receiver) : "Console"), new TextComponent(">: "), message);
+            }
+        };
         this.defaultChannel = this.globalChannel;
         this.playerManager = new SimplePlayerManager();
         Bukkit.getPluginManager().registerEvents(new ChatListener(this), this);

--- a/src/main/java/com/github/rmsy/channels/event/ChannelMessageEvent.java
+++ b/src/main/java/com/github/rmsy/channels/event/ChannelMessageEvent.java
@@ -3,6 +3,7 @@ package com.github.rmsy.channels.event;
 import com.github.rmsy.channels.Channel;
 import com.github.rmsy.channels.ChannelsEvent;
 import com.google.common.base.Preconditions;
+import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
@@ -18,7 +19,7 @@ public final class ChannelMessageEvent extends ChannelsEvent implements Cancella
     /** The message sender, or null for console. */
     private @Nullable final Player sender;
     /** The message to be sent. */
-    private String message;
+    private BaseComponent message;
     /** Whether or not the event is cancelled. */
     private boolean cancelled = false;
 
@@ -28,7 +29,7 @@ public final class ChannelMessageEvent extends ChannelsEvent implements Cancella
      * @param message The message.
      * @param sender  The sender, or null for console.
      */
-    public ChannelMessageEvent(String message, @Nullable final Player sender, Channel channel) {
+    public ChannelMessageEvent(BaseComponent message, @Nullable final Player sender, Channel channel) {
         this.message = Preconditions.checkNotNull(message, "message");
         this.sender = sender;
         this.channel = Preconditions.checkNotNull(channel, "Channel");
@@ -48,7 +49,7 @@ public final class ChannelMessageEvent extends ChannelsEvent implements Cancella
      *
      * @return The message to be sent.
      */
-    public String getMessage() {
+    public BaseComponent getMessage() {
         return message;
     }
 
@@ -57,7 +58,7 @@ public final class ChannelMessageEvent extends ChannelsEvent implements Cancella
      *
      * @param message The message to be sent.
      */
-    public void setMessage(String message) {
+    public void setMessage(BaseComponent message) {
         this.message = Preconditions.checkNotNull(message, "message");
     }
 

--- a/src/main/java/com/github/rmsy/channels/impl/SimpleChannel.java
+++ b/src/main/java/com/github/rmsy/channels/impl/SimpleChannel.java
@@ -4,98 +4,50 @@ import com.github.rmsy.channels.Channel;
 import com.github.rmsy.channels.event.ChannelMessageEvent;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permission;
 
 import javax.annotation.Nullable;
-import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Simple implementation of {@link Channel}. <p> This implementation of {@link Channel} supports several different
- * custom format variables: <table border="1"> <tbody> <tr> <th id="var">Variable</th> <th id="expl">Meaning</th> <th
- * id="ex">Examples</th> </tr> <tr> <td headers="var">{0}</td> <td headers="expl"> The sending {@link Player}'s name (or
- * "Console", if the sending {@link Player} is <code>null</code>. </td> <td headers="ex"> <ul> <li> If player
- * "iamramsey" sent a message, <code>{0}</code> would evaluate to "iamramsey". </li> <li> If a message was sent with a
- * <code>null</code> sender, <code>{0}</code> would evaluate to "Console". </li> </ul> </td> </tr> <tr> <td
- * headers="var">{1}</td> <td headers="expl"> The sending {@link Player}'s display name (or "§3*§6Console", if the
- * sending {@link Player} is <code>null</code>. </td> <td headers="ex"> <ul> <li> If player "iamramsey" (with display
- * name "§ciamramsey") sent a message, <code>{1}</code> would evaluate to "§ciamramsey". </li> <li> If a message was
- * sent with a <code>null</code> sender, <code>{1}</code> would evaluate to "§3*§6Console". </li> </ul> </td> </tr> <tr>
- * <td headers="var">{2}</td> <td headers="expl">The raw message.</td> <td headers="ex"> <ul> <li>If the message
- * "§cHello!" is sent, <code>{2}</code> would evaluate to "§cHello!".</li> </ul> </td> </tr> <tr> <td
- * headers="var">{3}</td> <td headers="expl"> The color-filtered message. The message is passed through {@link
- * ChatColor#stripColor}, removing any color codes. </td> <td headers="ex"> <ul> <li>If the message "§cHello!" is sent,
- * <code>{3}</code> would evaluate to "Hello!".</li> </ul> </td> </tr> </tbody> </table> <br/> </p>
+ * Simple implementation of {@link Channel}.
  */
-public class SimpleChannel implements Channel {
+public abstract class SimpleChannel implements Channel {
 
     /** The members of the channel (stored by their names) */
     private final Set<String> members;
     /** The permission node that will be broadcast from this channel to. */
     private final Permission permission;
-    /** The format. */
-    private String format;
-    private String broadcastFormat;
-
-    private SimpleChannel() {
-        this.members = null;
-        this.permission = null;
-    }
 
     /**
      * Creates a new SimpleChannel.
      *
-     * @param format     The format to be applied to messages.
      * @param permission The permission node that will be broadcast from this channel to.
      * @see SimpleChannel for detailed formatting information.
      */
-    public SimpleChannel(final String format, final String broadcastFormat, final Permission permission) {
-        this.format = Preconditions.checkNotNull(format, "format");
-        this.broadcastFormat = Preconditions.checkNotNull(broadcastFormat, "broadcast format");
+    public SimpleChannel(final Permission permission) {
         this.permission = Preconditions.checkNotNull(permission);
         this.members = new HashSet<>();
     }
 
-    public SimpleChannel(final String format, final Permission permission) {
-        this(format, format, permission);
-    }
-
     /**
-     * Gets the channel's format.
+     * Create the channel's format.
+     * This is called every time a message is about to be sent.
      *
-     * @return The channel's format.
-     * @see #setFormat(String)
+     * @param message the message.
+     * @param sender the sender, null if console.
+     * @param receiver the receiver.
+     * @param broadcast whether this is a broadcast message.
+     * @return the formatted component message.
+     * @see #sendMessageToViewer(Player, CommandSender, ChannelMessageEvent, boolean)
      */
-    @Override
-    public String getFormat() {
-        return this.format;
-    }
-
-    /**
-     * Sets the channel's format (the string that appears before the message).
-     *
-     * @param format The format.
-     * @see SimpleChannel for detailed formatting information.
-     */
-    @Override
-    public void setFormat(String format) {
-        this.format = Preconditions.checkNotNull(format, "format");
-    }
-
-    @Override
-    public String getBroadcastFormat() {
-        return this.broadcastFormat;
-    }
-
-    @Override
-    public void setBroadcastFormat(String format) {
-        this.broadcastFormat = Preconditions.checkNotNull(format, "format");
-    }
+    public abstract BaseComponent getFormat(BaseComponent message, @Nullable Player sender, CommandSender receiver, boolean broadcast);
 
     /**
      * Gets the users who are sending to this channel by default.
@@ -110,46 +62,74 @@ public class SimpleChannel implements Channel {
     /**
      * Sends a new message to the channel.
      *
-     * @param rawMessage The message to be sent.
-     * @param sender     The message sender, or null for console.
+     * @param message The message to be sent.
+     * @param sender The message sender, or null for console.
      * @return Whether or not the message was sent.
      */
     @Override
-    public boolean sendMessage(String rawMessage, @Nullable Player sender) {
-        ChannelMessageEvent event = new ChannelMessageEvent(rawMessage, sender, this);
+    public boolean sendMessage(BaseComponent message, @Nullable Player sender) {
+        return sendMessageToAll(message, sender, false);
+    }
+
+    /**
+     * Sends a new message to the channel.
+     *
+     * @param message The message to be sent.
+     * @param sender The message sender, or null for console.
+     * @return Whether or not the message was sent.
+     */
+    @Override
+    public boolean sendMessage(String message, @Nullable Player sender) {
+        return sendMessage(new TextComponent(message), sender);
+    }
+
+    /**
+     * Broadcasts a message to the channel.
+     *
+     * @param message The message to be broadcast.
+     */
+    @Override
+    public void broadcast(final BaseComponent message) {
+        this.sendMessageToAll(message, null, true);
+    }
+
+    /**
+     * Broadcasts a message to the channel.
+     *
+     * @param message The message to be broadcast.
+     */
+    @Override
+    public void broadcast(final String message) {
+        this.broadcast(new TextComponent(message));
+    }
+
+    public boolean sendMessageToAll(BaseComponent message, @Nullable Player sender, boolean broadcast) {
+        ChannelMessageEvent event = new ChannelMessageEvent(message, sender, this);
         Bukkit.getPluginManager().callEvent(event);
 
         if(event.isCancelled()) {
             return false;
         }
 
-        String sanitizedMessage = ChatColor.stripColor(Preconditions.checkNotNull(rawMessage, "Message"));
-
-        this.sendMessageToViewer(sender, Bukkit.getConsoleSender(), sanitizedMessage, event);
+        this.sendMessageToViewer(sender, Bukkit.getConsoleSender(), event, broadcast);
 
         for(Player viewer : Bukkit.getOnlinePlayers()) {
             if(viewer.hasPermission(this.permission)) {
-                this.sendMessageToViewer(sender, viewer, sanitizedMessage, event);
+                this.sendMessageToViewer(sender, viewer, event, broadcast);
             }
         }
 
         return true;
     }
 
-    public void sendMessageToViewer(Player sender, CommandSender viewer, String sanitizedMessage, ChannelMessageEvent event) {
-        boolean senderPresent = sender != null;
 
-        String senderName = senderPresent ? sender.getName(viewer) : "Console";
-        String senderDisplayName = senderPresent ? sender.getDisplayName(viewer) : ChatColor.GOLD + "*" + ChatColor.AQUA + "Console";
-        String format = senderPresent ? this.format : this.broadcastFormat;
-
-        viewer.sendMessage(MessageFormat.format(
-                format,
-                senderName,
-                senderDisplayName,
-                event.getMessage(),
-                sanitizedMessage
-        ));
+    public void sendMessageToViewer(Player sender, CommandSender viewer, ChannelMessageEvent event, boolean broadcast) {
+        BaseComponent component = getFormat(event.getMessage(), sender, viewer, broadcast);
+        if(viewer instanceof Player) {
+            ((Player) viewer).sendMessage(component);
+        } else {
+            viewer.sendMessage(component.toLegacyText());
+        }
     }
 
     /**
@@ -164,23 +144,13 @@ public class SimpleChannel implements Channel {
     }
 
     /**
-     * Broadcasts a message to the channel.
-     *
-     * @param message The message to be broadcast.
-     */
-    @Override
-    public void broadcast(final String message) {
-        this.sendMessage(message, null);
-    }
-
-    /**
      * Removes a user as a member.</br><b>Caution</b>: Only invoke this when the user has been (or will be) assigned as
      * a member to another channel.
      *
      * @param member The user.
      */
     protected final void removeMember(Player member) {
-        this.members.remove(Preconditions.checkNotNull(member, "member"));
+        this.members.remove(Preconditions.checkNotNull(member, "member").getName());
     }
 
     /**

--- a/src/main/java/com/github/rmsy/channels/impl/SimplePlayerManager.java
+++ b/src/main/java/com/github/rmsy/channels/impl/SimplePlayerManager.java
@@ -38,7 +38,7 @@ public class SimplePlayerManager implements PlayerManager {
      */
     @Override
     public void setMembershipChannel(Player player, Channel membershipChannel) {
-        SimpleChannel oldChannel = (SimpleChannel) this.playerMembershipMap.get(Preconditions.checkNotNull(player, "player"));
+        SimpleChannel oldChannel = (SimpleChannel) this.playerMembershipMap.get(Preconditions.checkNotNull(player, "player").getName());
         if (oldChannel != null) {
             oldChannel.removeMember(player);
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,7 +1,4 @@
 global-chat:
-  ## See http://rmsy.github.io/Channels
-  ## for detailed formatting information.
-  format: '§f<{1}§r§f>: {3}'
   switch:
     success-msg: Changed default channel to global chat.
     no-change-msg: Global chat is already your default channel.


### PR DESCRIPTION
Instead of using static string formatting, a `SimpleChannel` uses `#getFormat()` to dynamically generate a component message format. This means implementors inject special components (ie. click name to teleport).

This is a breaking change because of the formatting; however, you can still send messages and broadcasts as a string (it's converted to `TextComponent`).